### PR TITLE
Avoid inconsistencies by using extension methods to parse/stringify numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+.idea

--- a/BmsLoader.cs
+++ b/BmsLoader.cs
@@ -1,5 +1,4 @@
-﻿using System.Globalization;
-using System.Text.Json.Nodes;
+﻿using System.Text.Json.Nodes;
 using CustomAlbums.Data;
 using CustomAlbums.Managers;
 using CustomAlbums.Utilities;
@@ -64,11 +63,11 @@ namespace CustomAlbums
                     if (!key.Contains("BPM")) continue;
 
                     var bpmKey = string.IsNullOrEmpty(key[3..]) ? "00" : key[3..];
-                    bpmDict.Add(bpmKey, float.Parse(value, CultureInfo.InvariantCulture));
+                    bpmDict.Add(bpmKey, value.ParseAsFloat());
 
                     if (bpmKey != "00") continue;
 
-                    var freq = 60f / float.Parse(value, CultureInfo.InvariantCulture) * 4f;
+                    var freq = 60f / value.ParseAsFloat() * 4f;
                     var obj = new JsonObject
                     {
                         { "tick", 0f },
@@ -83,7 +82,7 @@ namespace CustomAlbums
                     var key = split[0];
                     var value = split[1];
 
-                    var beat = int.Parse(key[..3], CultureInfo.InvariantCulture);
+                    var beat = key[..3].ParseAsInt();
                     var typeCode = key.Substring(3, 2);
                     
                     if (!Bms.Channels.ContainsKey(typeCode)) continue;
@@ -95,7 +94,7 @@ namespace CustomAlbums
                         var obj = new JsonObject
                         {
                             { "beat", beat },
-                            { "percent", float.Parse(value, CultureInfo.InvariantCulture) }
+                            { "percent", value.ParseAsFloat() }
                         };
                         notePercents.Add(beat, obj);
                     }
@@ -549,7 +548,7 @@ namespace CustomAlbums
         private static void ProcessDelay(Bms bms)
         {
             var scene = bms.Info["GENRE"]?.GetValue<string>() ?? string.Empty;
-            var sceneIndex = int.Parse(scene.Split('_')[1], CultureInfo.InvariantCulture);
+            var sceneIndex = scene.Split('_')[1].ParseAsInt();
             var sceneInfo = Singleton<StageBattleComponent>.instance.sceneInfo;
             var delayCache = new Dictionary<string, Decimal>();
 

--- a/Data/Bms.cs
+++ b/Data/Bms.cs
@@ -1,5 +1,4 @@
-﻿using System.Globalization;
-using System.Text.Json.Nodes;
+﻿using System.Text.Json.Nodes;
 using CustomAlbums.Utilities;
 using Il2CppAssets.Scripts.GameCore.Managers;
 using Il2CppAssets.Scripts.PeroTools.Commons;
@@ -317,7 +316,7 @@ namespace CustomAlbums.Data
             get
             {
                 var bpmString = Info["BPM"]?.GetValue<string>() ?? Info["BPM01"]?.GetValue<string>() ?? string.Empty;
-                return !float.TryParse(bpmString, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var bpm) ? 0f : bpm;
+                return bpmString.TryParseAsFloat(out var bpm) ? bpm : 0f;
             }
         }
 
@@ -412,7 +411,7 @@ namespace CustomAlbums.Data
             if (NoteData is null || NoteData.Count == 0) InitNoteData();
             var processed = new JsonArray();
 
-            var speedAir = int.Parse(Info["PLAYER"]?.GetValue<string>() ?? "1", CultureInfo.InvariantCulture);
+            var speedAir = (Info["PLAYER"]?.GetValue<string>() ?? "1").ParseAsInt();
             var speedGround = speedAir;
 
             var objectId = 1;

--- a/Data/Sheet.cs
+++ b/Data/Sheet.cs
@@ -1,5 +1,4 @@
 ﻿using System.Text.Json.Nodes;
-using CustomAlbums.Managers;
 using CustomAlbums.Utilities;
 using Il2CppAssets.Scripts.Database;
 using Il2CppAssets.Scripts.GameCore;

--- a/Managers/AlbumManager.cs
+++ b/Managers/AlbumManager.cs
@@ -1,6 +1,5 @@
-﻿using System.Globalization;
-using System.IO.Enumeration;
-using CustomAlbums.Data;
+﻿using CustomAlbums.Data;
+using CustomAlbums.Utilities;
 using Il2CppPeroTools2.Resources;
 using UnityEngine;
 using Logger = CustomAlbums.Utilities.Logger;
@@ -80,7 +79,7 @@ namespace CustomAlbums.Managers
 
         public static Album GetByUid(string uid)
         {
-            return LoadedAlbums.FirstOrDefault(album => album.Value.Index == int.Parse(uid[4..], CultureInfo.InvariantCulture)).Value;
+            return LoadedAlbums.FirstOrDefault(album => album.Value.Index == uid[4..].ParseAsInt()).Value;
         }
         public static string GetAlbumNameFromUid(string uid)
         {

--- a/Managers/SaveManager.cs
+++ b/Managers/SaveManager.cs
@@ -1,5 +1,4 @@
-﻿using System.Globalization;
-using System.Text;
+﻿using System.Text;
 using System.Text.Json;
 using CustomAlbums.Data;
 using CustomAlbums.Utilities;
@@ -171,7 +170,7 @@ namespace CustomAlbums.Managers
             newScore.Score = Math.Max(score, newScore.Score);
             newScore.Combo = Math.Max(maxCombo, newScore.Combo);
             newScore.Evaluate = Math.Max(newEvaluate, newScore.Evaluate);
-            newScore.AccuracyStr = string.Create(CultureInfo.InvariantCulture, $"{newScore.Accuracy / 100:P2}");
+            newScore.AccuracyStr = (newScore.Accuracy / 100).ToStringInvariant("P2");
             newScore.Clear++;
 
             if (musicDifficulty is 2 && AlbumManager.LoadedAlbums[albumName].Sheets.ContainsKey(3) && newScore.Evaluate >= 4)

--- a/Patches/AssetPatch.cs
+++ b/Patches/AssetPatch.cs
@@ -1,5 +1,4 @@
-﻿using System.Globalization;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -205,7 +204,7 @@ namespace CustomAlbums.Patches
                     AlbumManager.LoadedAlbums.TryGetValue(albumKey, out var album);
                     if (suffix.StartsWith("_map"))
                     {
-                        newAsset = album?.Sheets[int.Parse(suffix[^1].ToString(), CultureInfo.InvariantCulture)].GetStage();
+                        newAsset = album?.Sheets[suffix[^1].ToString().ParseAsInt()].GetStage();
                         // Do not cache the StageInfos, this should be loaded into memory only when we need it
                         cache = false;
                     }
@@ -290,7 +289,7 @@ namespace CustomAlbums.Patches
 
             Logger.Msg($"Loading {assetName}!");
 
-            if (assetName.StartsWith("ALBUM") && int.TryParse(assetName.AsSpan(5), NumberStyles.Number, CultureInfo.InvariantCulture, out var albumNum) &&
+            if (assetName.StartsWith("ALBUM") && assetName[5..].TryParseAsInt(out var albumNum) &&
                 albumNum != AlbumManager.Uid + 1)
             {
                 // If done loading albums, we've found the maximum actual album

--- a/Patches/HiddenSupportPatch.cs
+++ b/Patches/HiddenSupportPatch.cs
@@ -1,5 +1,4 @@
-﻿using System.Globalization;
-using CustomAlbums.Managers;
+﻿using CustomAlbums.Managers;
 using CustomAlbums.Utilities;
 using HarmonyLib;
 using Il2Cpp;
@@ -45,7 +44,7 @@ namespace CustomAlbums.Patches
                                 albumUid,
                                 value.Info.HideBmsDifficulty == "0"
                                     ? value.Sheets.ContainsKey(3) ? 3 : 2
-                                    : int.Parse(value.Info.HideBmsDifficulty, CultureInfo.InvariantCulture),
+                                    : value.Info.HideBmsDifficulty.ParseAsInt(),
                                 4,
                                 $"{key}_map4",
                                 (Il2CppSystem.Func<bool>)delegate { return __instance.IsInvokeHideBms(albumUid); }

--- a/Patches/MikuSceneSupportPatch.cs
+++ b/Patches/MikuSceneSupportPatch.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using CustomAlbums.Utilities;
+using HarmonyLib;
 using Il2CppGameLogic;
 
 namespace CustomAlbums.Patches
@@ -14,9 +15,9 @@ namespace CustomAlbums.Patches
         {
             private static void Finalizer(string sceneFestivalName, ref string __result)
             {
+                var subStr = sceneFestivalName[6..];
                 
-                if (sceneFestivalName.AsSpan(6).Length <= 2 ||
-                    !int.TryParse(sceneFestivalName.AsSpan(6).ToString(), out var sceneIndex)) return;
+                if (subStr.Length <= 2 || !subStr.TryParseAsInt(out var sceneIndex)) return;
                 
                 // For some reason, scene change 1X sets scene to scene_010, which is invalid
                 // Just trim off "scene_" and parse the numbers after the underscore to int again to get 10 instead of 010

--- a/Patches/SavePatch.cs
+++ b/Patches/SavePatch.cs
@@ -1,5 +1,4 @@
-﻿using System.Globalization;
-using System.Reflection;
+﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text.Json.Nodes;
@@ -66,11 +65,11 @@ namespace CustomAlbums.Patches
             // Sets all the PnlRecord data to custom chart data.
             var evaluate = data["Evaluate"]!.GetValue<int>();
             panel.txtAccuracy.text = data["AccuracyStr"]!.GetValue<string>();
-            panel.txtClear.text = data["Clear"]!.GetValue<float>().ToString(CultureInfo.InvariantCulture);
-            panel.txtCombo.text = data["Combo"]!.GetValue<int>().ToString(CultureInfo.InvariantCulture);
+            panel.txtClear.text = data["Clear"]!.GetValue<float>().ToStringInvariant();
+            panel.txtCombo.text = data["Combo"]!.GetValue<int>().ToStringInvariant();
             panel.txtGrade.text = EvalToGrade[evaluate];
             panel.txtGrade.color = panel.gradeColor[evaluate];
-            panel.txtScore.text = data["Score"]!.GetValue<int>().ToString(CultureInfo.InvariantCulture);
+            panel.txtScore.text = data["Score"]!.GetValue<int>().ToStringInvariant();
         }
 
         /// <summary>

--- a/Utilities/Formatting.cs
+++ b/Utilities/Formatting.cs
@@ -1,0 +1,32 @@
+using System.Globalization;
+
+namespace CustomAlbums.Utilities;
+
+public static class Formatting {
+    public static int ParseAsInt(this string value)
+        => int.Parse(value, NumberStyles.Number, CultureInfo.InvariantCulture);
+
+    public static float ParseAsFloat(this string value)
+        => float.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture);
+
+    public static decimal ParseAsDecimal(this string value)
+        => decimal.Parse(value, NumberStyles.Number, CultureInfo.InvariantCulture);
+    
+    public static bool TryParseAsInt(this string value, out int result)
+        => int.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out result);
+    
+    public static bool TryParseAsFloat(this string value, out float result)
+        => float.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out result);
+    
+    public static bool TryParseAsDecimal(this string value, out decimal result)
+        => decimal.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out result);
+    
+    public static string ToStringInvariant(this int value, string format = "")
+        => value.ToString(format, CultureInfo.InvariantCulture);
+    
+    public static string ToStringInvariant(this float value, string format = "")
+        => value.ToString(format, CultureInfo.InvariantCulture);
+    
+    public static string ToStringInvariant(this decimal value, string format = "")
+        => value.ToString(format, CultureInfo.InvariantCulture);
+}

--- a/Utilities/Json.cs
+++ b/Utilities/Json.cs
@@ -1,5 +1,4 @@
-﻿using System.Globalization;
-using System.Text.Json;
+﻿using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Il2CppNewtonsoft.Json;
@@ -54,14 +53,12 @@ namespace CustomAlbums.Utilities
         /// <returns>The decimal value</returns>
         public static decimal GetValueAsDecimal(this JsonNode node)
         {
-            return decimal.TryParse(node.ToString(), NumberStyles.Number, CultureInfo.InvariantCulture, out var result) ? result : 0M;
+            return node.ToString().TryParseAsDecimal(out var result) ? result : 0M;
         }
 
         public static Decimal GetValueAsIl2CppDecimal(this JsonNode node)
         {
-            return decimal.TryParse(node.ToString(), NumberStyles.Number, CultureInfo.InvariantCulture, out var result)
-                ? (Decimal)(float)result
-                : Decimal.Zero;
+            return (Decimal)(float)node.GetValueAsDecimal();
         }
     }
 }


### PR DESCRIPTION
Replaces all .Parse/.TryParse/.ToString with .ParseAs/.TryParseAs/.ToStringInvariant extension methods to avoid inconsistencies and improve codestyle by not putting the same `CultureInfo.Invariant` everywhere
