### PR TITLE
Add custom album hot reload support

### DIFF
--- a/Data/Album.cs
+++ b/Data/Album.cs
@@ -259,11 +259,13 @@ namespace CustomAlbums.Data
         }
         private void GetSheets()
         {
-            // Adds to the Sheets dictionary
-            foreach (var difficulty in Info.Difficulties.Keys.Where(difficulty => HasFile($"map{difficulty}.bms")))
+            // Always populate all 5 difficulties so Headquarters doesn't throw KeyNotFoundException
+            for (var difficulty = 1; difficulty <= 5; difficulty++)
+            {
                 Sheets.Add(difficulty, new Sheet(this, difficulty));
+            }
         }
 
-        public bool HasDifficulty(int difficulty) => Sheets.ContainsKey(difficulty);
+        public bool HasDifficulty(int difficulty) => Sheets.TryGetValue(difficulty, out var sheet) && sheet.HasFile;
     }
 }

--- a/Data/Sheet.cs
+++ b/Data/Sheet.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Nodes;
+using System.Text.Json.Nodes;
 using CustomAlbums.Utilities;
 using Il2CppAssets.Scripts.Database;
 using Il2CppAssets.Scripts.GameCore;
@@ -21,17 +21,30 @@ namespace CustomAlbums.Data
         public string MapName { get; }
         public int Difficulty { get; }
         public bool TalkFileVersion2 { get; set; }
+        
+        public bool HasFile => ParentAlbum.HasFile($"map{Difficulty}.bms");
         public string Md5
         {
             get
             {
-                using var stream = ParentAlbum.OpenMemoryStream($"map{Difficulty}.bms");
-                return stream.GetHash();
+                if (!HasFile) return "00000000000000000000000000000000";
+                try
+                {
+                    using var stream = ParentAlbum.OpenMemoryStream($"map{Difficulty}.bms");
+                    return stream.GetHash();
+                }
+                catch (System.Exception ex)
+                {
+                    Logger.Warning($"Failed to calculate MD5 for {MapName}: {ex.Message}");
+                    return "00000000000000000000000000000000";
+                }
             }
         }
 
         public StageInfo GetStage()
         {
+            if (!HasFile) return null;
+
             // If opening a FileStream is possible (i.e. reading from a folder) then open it as FileStream
             // Otherwise open it as a MemoryStream
             // This allows writing to the map BMS file while it is being read

--- a/Managers/AudioManager.cs
+++ b/Managers/AudioManager.cs
@@ -16,16 +16,14 @@ namespace CustomAlbums.Managers
     {
         public const int AsyncReadSpeed = 4096;
 
-        private static Coroutine _currentCoroutine;
         private static readonly Dictionary<string, Coroutine> Coroutines = new();
         private static readonly Logger Logger = new(nameof(AudioManager));
 
         public static bool SwitchLoad(string name)
         {
-            if (!Coroutines.TryGetValue(name, out var routine)) return false;
-            _currentCoroutine = routine;
+            if (!Coroutines.ContainsKey(name)) return false;
 
-            Logger.Msg($"Switching to async load of {name}");
+            Logger.Msg($"Async load already in progress for {name}");
             return true;
         }
 
@@ -50,14 +48,10 @@ namespace CustomAlbums.Managers
                 if (audioClip == null)
                 {
                     Coroutines.Remove(name);
-                    if (_currentCoroutine == coroutine) _currentCoroutine = null;
 
                     Logger.Msg($"Aborting async load of {name}.mp3");
                     return true;
                 }
-
-                // Pause coroutine if it is not active
-                if (coroutine != _currentCoroutine) return false;
 
                 var sampleArray = new float[Math.Min(AsyncReadSpeed, remainingSamples)];
                 var readCount = mp3.ReadSamples(sampleArray, 0, sampleArray.Length);
@@ -73,14 +67,12 @@ namespace CustomAlbums.Managers
                 stream.Dispose();
 
                 Coroutines.Remove(name);
-                _currentCoroutine = null;
 
                 Logger.Msg($"Finished async load of {name}.mp3");
                 return true;
             });
 
             Coroutines[name] = coroutine;
-            _currentCoroutine = coroutine;
 
             return audioClip;
         }
@@ -102,14 +94,10 @@ namespace CustomAlbums.Managers
                 if (audioClip == null)
                 {
                     Coroutines.Remove(name);
-                    if (_currentCoroutine == coroutine) _currentCoroutine = null;
 
                     Logger.Msg($"Aborting async load of {name}.ogg");
                     return true;
                 }
-
-                // Pause coroutine if it is not active
-                if (coroutine != _currentCoroutine) return false;
 
                 var sampleArray = new float[Math.Min(AsyncReadSpeed, remainingSamples)];
                 var readCount = ogg.Read(sampleArray, 0, sampleArray.Length);
@@ -130,7 +118,6 @@ namespace CustomAlbums.Managers
                     stream.Dispose();
 
                     Coroutines.Remove(name);
-                    _currentCoroutine = null;
                     return true;
                 }
 
@@ -143,14 +130,12 @@ namespace CustomAlbums.Managers
                 stream.Dispose();
 
                 Coroutines.Remove(name);
-                _currentCoroutine = null;
 
                 Logger.Msg($"Finished async load of {name}.ogg");
                 return true;
             });
 
             Coroutines[name] = coroutine;
-            _currentCoroutine = coroutine;
 
             return audioClip;
         }

--- a/Managers/HotReloadManager.cs
+++ b/Managers/HotReloadManager.cs
@@ -1,29 +1,79 @@
-﻿using CustomAlbums.Patches;
+using System.Collections.Concurrent;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using CustomAlbums.Data;
+using CustomAlbums.Patches;
 using CustomAlbums.Utilities;
 using HarmonyLib;
+using Il2Cpp;
 using Il2CppAssets.Scripts.Database;
+using Il2CppAssets.Scripts.Database.DataClass;
+using Il2CppAssets.Scripts.PeroTools.Commons;
+using Il2CppAssets.Scripts.PeroTools.GeneralLocalization;
+using Il2CppAssets.Scripts.PeroTools.Managers;
 using Il2CppAssets.Scripts.UI.Panels;
+using Il2CppInterop.Runtime.InteropTypes.Arrays;
+using Il2CppPeroTools2.Resources;
+using static Il2CppAssets.Scripts.Database.DBConfigCustomTags;
 
 namespace CustomAlbums.Managers
 {
-    // TODO: Fix all of this with album.AlbumName
     internal static class HotReloadManager
     {
         private static readonly Logger Logger = new(nameof(HotReloadManager));
-        private static Queue<string> AlbumsAdded { get; } = new();
-        private static Queue<string> AlbumsDeleted { get; } = new();
-        private static List<string> AlbumUidsAdded { get; } = new();
+
+        // Localization texts for the notification banner
+        private static readonly Dictionary<string, string> AddedTranslations = new()
+        {
+            { "English", "Added {0} charts" },
+            { "ChineseS", "添加了 {0} 张谱面" },
+            { "ChineseT", "添加了 {0} 張譜面" },
+            { "Japanese", "{0}個の譜面を追加しました" },
+            { "Korean", "{0}개의 보면을 추가했습니다" }
+        };
+
+        private static readonly Dictionary<string, string> DeletedTranslations = new()
+        {
+            { "English", "Deleted {0} charts" },
+            { "ChineseS", "删除了 {0} 张谱面" },
+            { "ChineseT", "删除了 {0} 張譜面" },
+            { "Japanese", "{0}個の譜面を削除しました" },
+            { "Korean", "{0}개의 보면을 삭제했습니다" }
+        };
+
+        // Gets the formatted notification for the current language
+        private static string GetLocalizedMessage(Dictionary<string, string> translations, int count)
+        {
+            var language = SingletonScriptableObject<LocalizationSettings>.instance?.GetActiveOption("Language") ?? "English";
+            if (!translations.TryGetValue(language, out var format))
+            {
+                format = translations["English"];
+            }
+            return string.Format(format, count);
+        }
+
+        // Thread-safe queues for FileSystemWatcher background events
+        private static ConcurrentQueue<string> AlbumsToAdd { get; } = new();
+
+        private static ConcurrentQueue<string> AlbumsToDelete { get; } = new();
+        private static ConcurrentDictionary<string, DateTime> LastFileEvent { get; } = new();
         private static PnlStage PnlStageInstance { get; set; }
 
+        // Hot-loaded MusicInfo cache: uid -> MusicInfo
+        // Used by GetMusicInfoFromAll Harmony Postfix
+        private static readonly Dictionary<string, MusicInfo> HotLoadedMusicInfos = new();
+        private static readonly Dictionary<string, string> HotLoadedMusicNames = new();
+        private static readonly Dictionary<string, string> HotLoadedMusicAuthors = new();
+
+        /// <summary>
+        ///     Checks if a file is fully written and no longer locked by other processes.
+        /// </summary>
         private static bool IsFileUnlocked(string path)
         {
             try
             {
-                using var fileStream = File.Open(path, FileMode.Open);
-                if (fileStream.Length <= 0) return false;
-
-                Logger.Msg("The added album is ready to be read!");
-                return true;
+                using var fileStream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.None);
+                return fileStream.Length > 0;
             }
             catch (Exception ex) when (ex is FileNotFoundException or IOException)
             {
@@ -31,107 +81,681 @@ namespace CustomAlbums.Managers
             }
         }
 
-        private static void RemoveAllCachedAssets(string albumName)
+
+        private static int ParseDifficulty(string difficulty)
         {
-            Logger.Msg("Removing " + albumName + "!");
-
-            if (!AlbumManager.LoadedAlbums.TryGetValue($"album_{albumName}", out var album)) return;
-
-            // Remove cached album information, not needed anymore since the album has been deleted
-            AlbumManager.LoadedAlbums.Remove($"album_{albumName}");
-            CoverManager.CachedAnimatedCovers.Remove(album.Index);
-            CoverManager.CachedCovers.Remove(album.Index);
-            AssetPatch.RemoveFromCache($"album_{albumName}_demo");
-            AssetPatch.RemoveFromCache($"album_{albumName}_music");
-            AssetPatch.RemoveFromCache($"album_{albumName}_cover");
-
-            // Get the music info from the UID, remove it from the ShowMusic list, and refresh the UI
-            var musicInfo = GlobalDataBase.s_DbMusicTag.GetMusicInfoFromAll($"{AlbumManager.Uid}-{album.Index}");
-            GlobalDataBase.s_DbMusicTag.RemoveShowMusicUid(musicInfo);
-            PnlStageInstance.m_MusicRootAnimator?.Play(PnlStageInstance.animNameAlbumIn);
-            PnlStageInstance.RefreshMusicFSV();
-
-            // TODO: Remove the album information from the Custom Albums tag menu
-
-            // TODO: Only change the selected album if the selected album was the album that was deleted
-            Logger.Msg("Successfully removed from cache!");
+            return int.TryParse(difficulty, out var value) ? value : 0;
         }
 
-        private static void RenameAllCachedAssets(string oldAlbumName, string newAlbumName)
+        private static MusicExInfo CreateMusicExInfo(Album album)
         {
-            Logger.Msg($"Renaming {oldAlbumName} to {newAlbumName}!");
-            var success = AlbumManager.LoadedAlbums.Remove(oldAlbumName, out var album);
-            if (!success) return;
+            var albumInfo = album.Info;
+            var changedDiff = new Il2CppStructArray<int>(5);
+            changedDiff[0] = ParseDifficulty(albumInfo.Difficulty1);
+            changedDiff[1] = ParseDifficulty(albumInfo.Difficulty2);
+            changedDiff[2] = ParseDifficulty(albumInfo.Difficulty3);
+            changedDiff[3] = ParseDifficulty(albumInfo.Difficulty4);
+            changedDiff[4] = ParseDifficulty(albumInfo.Difficulty5);
 
-            // rename the assets to the new name
-            AlbumManager.LoadedAlbums.TryAdd(newAlbumName, album);
-            AssetPatch.ModifyCacheKey($"{oldAlbumName}_demo", $"{newAlbumName}_demo");
-            AssetPatch.ModifyCacheKey($"{oldAlbumName}_music", $"{newAlbumName}_music");
-            AssetPatch.ModifyCacheKey($"{oldAlbumName}_cover", $"{newAlbumName}_cover");
-
-            Logger.Msg("Successfully modified cache!");
-        }
-
-        private static void AddNewAlbums(int previousSize)
-        {
-            var index = previousSize;
-            for (var i = previousSize; i < AlbumManager.LoadedAlbums.Count; i++)
-            {
-                // TODO: Write added album hot reloading logic here
-            }
-
-            PnlStageInstance.m_MusicRootAnimator?.Play(PnlStageInstance.animNameAlbumIn);
-            PnlStageInstance.RefreshMusicFSV();
+            var musicExInfo = new MusicExInfo();
+            musicExInfo.m_AlbumIndex = AlbumManager.Uid + 1;
+            musicExInfo.m_AlbumUidIndex = AlbumManager.Uid;
+            musicExInfo.m_MusicIndex = album.Index;
+            musicExInfo.m_AlbumUidName = $"music_package_{AlbumManager.Uid}";
+            musicExInfo.m_AlbumJsonName = AlbumManager.JsonName;
+            musicExInfo.m_ChangedDiff = changedDiff;
+            return musicExInfo;
         }
 
         /// <summary>
-        ///     Runs the logic for hot reloading on Unity's FixedUpdate
+        ///     Hot-add: Injects a new .mdm file into the game's runtime database.
+        /// </summary>
+        private static int ProcessAdditions()
+        {
+            var addedCount = 0;
+
+            while (AlbumsToAdd.TryDequeue(out var path))
+            {
+                try
+                {
+                    // 1. Load album into AlbumManager
+                    var album = AlbumManager.LoadOne(path);
+                    if (album == null)
+                    {
+                        Logger.Warning($"HotReload: Failed to load album from {path}");
+                        continue;
+                    }
+
+                    var albumName = album.AlbumName;
+                    var uid = $"{AlbumManager.Uid}-{album.Index}";
+                    var albumInfo = album.Info;
+                    Logger.Msg($"HotReload: Adding {albumName} (UID: {uid})", false);
+
+                    // 2. Transmute: Native DBObject generation via JSON
+                    // Instead of reflection, re-serialize ALL custom albums and let the game natively deserialize them!
+                    var masterAlbums = Singleton<ConfigManager>.instance.GetConfigObject<DBConfigAlbums>(-1);
+                    var albumsInfo = masterAlbums?.GetAlbumsInfoByUid(AlbumManager.MusicPackage);
+                    var globalAlbumConfig = albumsInfo != null 
+                        ? Singleton<ConfigManager>.instance.GetConfigObject<DBConfigALBUM>(albumsInfo.albumJsonIndex) 
+                        : null;
+
+                    if (globalAlbumConfig != null)
+                    {
+                        var jsonArray = new JsonArray();
+                        var localJsonArray = new JsonArray();
+
+                        foreach (var (albumStr, albumObj) in AlbumManager.LoadedAlbums)
+                        {
+                            var aInfo = albumObj.Info;
+                            var displayName = aInfo.Name ?? "";
+
+                            var customChartJson = new
+                            {
+                                uid = albumObj.Uid,
+                                name = displayName,
+                                author = aInfo.Author ?? "",
+                                bpm = aInfo.Bpm ?? "0",
+                                music = $"{albumStr}_music",
+                                demo = $"{albumStr}_demo",
+                                cover = $"{albumStr}_cover",
+                                noteJson = $"{albumStr}_map",
+                                scene = aInfo.Scene ?? "scene_01",
+                                unlockLevel = "0",
+                                levelDesigner = aInfo.LevelDesigner ?? "",
+                                levelDesigner1 = aInfo.LevelDesigner1 ?? aInfo.LevelDesigner ?? "",
+                                levelDesigner2 = aInfo.LevelDesigner2 ?? aInfo.LevelDesigner ?? "",
+                                levelDesigner3 = aInfo.LevelDesigner3 ?? aInfo.LevelDesigner ?? "",
+                                levelDesigner4 = aInfo.LevelDesigner4 ?? aInfo.LevelDesigner ?? "",
+                                levelDesigner5 = aInfo.LevelDesigner5 ?? aInfo.LevelDesigner ?? "",
+                                difficulty1 = aInfo.Difficulty1 ?? "0",
+                                difficulty2 = aInfo.Difficulty2 ?? "0",
+                                difficulty3 = aInfo.Difficulty3 ?? "0",
+                                difficulty4 = aInfo.Difficulty4 ?? "0",
+                                difficulty5 = aInfo.Difficulty5 ?? "0"
+                            };
+                            jsonArray.Add(JsonSerializer.SerializeToNode(customChartJson));
+
+                            localJsonArray.Add(JsonSerializer.SerializeToNode(new
+                            {
+                                name = displayName,
+                                author = aInfo.Author ?? ""
+                            }));
+                        }
+
+                        var fullJsonStr = JsonSerializer.Serialize(jsonArray);
+                        var fullLocalJsonStr = JsonSerializer.Serialize(localJsonArray);
+
+                        // 1. Re-deserialize the entire list of custom albums into the global config
+                        globalAlbumConfig.Deserialize(fullJsonStr);
+                        
+                        // 2. Bypass engine cache completely by manually instantiating and injecting the localized databases
+                        var localDicProp = typeof(BaseDBConfigLocalObject<DBConfigLocalALBUM, LocalALBUMInfo>).GetProperty("m_LocalDic", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                        if (localDicProp != null)
+                        {
+                            var globalLocalDic = localDicProp.GetValue(globalAlbumConfig) as Il2CppSystem.Collections.Generic.Dictionary<int, DBConfigLocalALBUM>;
+                            if (globalLocalDic != null)
+                            {
+                                globalLocalDic.Clear();
+                                for (int i = 0; i <= 15; i++)
+                                {
+                                    var newLocalAlbum = new DBConfigLocalALBUM();
+                                    newLocalAlbum.Deserialize(fullLocalJsonStr);
+                                    globalLocalDic.Add(i, newLocalAlbum);
+                                }
+                            }
+                        }
+
+                        // 4. Update the global dictionaries
+                        GlobalDataBase.s_DbMusicTag.AddAllMusicInfo(globalAlbumConfig);
+
+                        // 4. Re-initialize ExInfo for all the newly created MusicInfo objects
+                        var newMusicInfoList = new Il2CppSystem.Collections.Generic.List<MusicInfo>();
+                        globalAlbumConfig.GetAllMusicInfo(newMusicInfoList);
+                        int idx = 0;
+                        foreach (var m in newMusicInfoList)
+                        {
+                            var uidSplit = m.uid.Split('-');
+                            if (uidSplit.Length < 2) { idx++; continue; }
+                            if (!int.TryParse(uidSplit[1], out var parsedIndex)) { idx++; continue; }
+
+                            var aObj = AlbumManager.LoadedAlbums.Values.FirstOrDefault(a => a.Index == parsedIndex);
+                            if (aObj != null)
+                            {
+                                m.Init(idx);
+                                m.InitExInfo();
+                                m.m_MusicExInfo = CreateMusicExInfo(aObj);
+
+                                HotLoadedMusicInfos[m.uid] = m;
+                                HotLoadedMusicNames[m.uid] = aObj.Info.Name ?? "";
+                                HotLoadedMusicAuthors[m.uid] = aObj.Info.Author ?? "";
+                            }
+                            idx++;
+                        }
+
+                        Logger.Msg($"HotReload: Natively transmuted MusicInfo for {uid}", false);
+                    }
+                    else
+                    {
+                        Logger.Error("HotReload: globalAlbumConfig is null! Cannot inject metadata.");
+                    }
+
+                    // Add to the front-end view list so UI updates correctly
+                    try
+                    {
+                        var dhColBase = Il2CppAssets.Scripts.Database.DataHelper.collections;
+                        var dhColPtr = dhColBase != null ? dhColBase.Pointer : IntPtr.Zero;
+                        var uids = GlobalDataBase.s_DbMusicTag.m_StageShowMusicUids;
+                        if (uids != null)
+                        {
+                            if (!uids.Contains(uid))
+                            {
+                                // Only add if it's not currently displaying the collections list to avoid alias pollution
+                                if (dhColPtr == IntPtr.Zero || uids.Pointer != dhColPtr)
+                                {
+                                    uids.Add(uid);
+                                    Logger.Msg($"HotReload: Added {uid} to m_StageShowMusicUids", false);
+                                }
+                            }
+                        }
+                        // Add to All Music tag (Index 0)
+
+                        var allMusicTag = GlobalDataBase.dbMusicTag.GetAlbumTagInfo(0);
+                        if (allMusicTag != null)
+                        {
+                            if (allMusicTag.m_MusicUids != null && !allMusicTag.m_MusicUids.Contains(uid))
+                            {
+                                if (allMusicTag.m_MusicUids.Pointer != dhColPtr)
+                                    allMusicTag.m_MusicUids.Add(uid);
+                            }
+                            if (allMusicTag.m_DisplayMusicUids != null)
+                            {
+                                foreach (var d in allMusicTag.m_DisplayMusicUids)
+                                {
+                                    if (d.musicUids != null && !d.musicUids.Contains(uid))
+                                    {
+                                        if (d.musicUids.Pointer != dhColPtr)
+                                            d.musicUids.Add(uid);
+                                    }
+                                }
+                            }
+                        }
+
+                        // 5. Removed dicLevelConfig injection. It was causing Headquarters to crash by supplying an incorrect difficulty level.
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Warning($"HotReload: Failed to add to view lists: {ex.Message}");
+                    }
+                    
+                    // 3. Inject search tags into ConfigManager
+                    try
+                    {
+                        var config = Singleton<ConfigManager>.instance.GetConfigObject<DBConfigMusicSearchTag>();
+                        var searchTag = new MusicSearchTagInfo
+                        {
+                            uid = uid,
+                            listIndex = config.count
+                        };
+
+                        var tags = new List<string> { "custom albums" };
+                        if (albumInfo.SearchTags != null) tags.AddRange(albumInfo.SearchTags);
+                        if (!string.IsNullOrEmpty(albumInfo.NameRomanized)) tags.Add(albumInfo.NameRomanized);
+                        for (var i = 0; i < tags.Count; i++) tags[i] = tags[i].ToLower();
+                        searchTag.tag = new Il2CppInterop.Runtime.InteropTypes.Arrays.Il2CppStringArray(tags.ToArray());
+
+                        if (!config.m_Dictionary.ContainsKey(uid))
+                        {
+                            config.m_Dictionary.Add(uid, searchTag);
+                            config.list.Add(searchTag);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Warning($"HotReload: Failed to add search tags: {ex.Message}");
+                    }
+
+                    // 4. Preload cover resources
+                    try
+                    {
+                        if (album.HasFile("cover.png") || album.HasFile("cover.gif"))
+                        {
+                            ResourcesManager.instance
+                                .LoadFromName<UnityEngine.Sprite>($"{albumName}_cover")
+                                .hideFlags |= UnityEngine.HideFlags.DontUnloadUnusedAsset;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Warning($"HotReload: Failed to preload cover: {ex.Message}");
+                    }
+
+                    // UI Hijack will handle rendering the name and author without needing these native injections.
+                    addedCount++;
+                    Logger.Msg($"HotReload: Successfully added {albumInfo.Name}", false);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warning($"HotReload: Error adding album: {ex.Message}");
+                    Logger.Warning(ex.StackTrace);
+                }
+            }
+
+            return addedCount;
+        }
+
+        /// <summary>
+        ///     Hot-delete: Removes a specified album from the game's runtime database.
+        /// </summary>
+        private static int ProcessDeletions()
+        {
+            var deletedCount = 0;
+
+            while (AlbumsToDelete.TryDequeue(out var albumFileName))
+            {
+                try
+                {
+                    var albumKey = $"album_{albumFileName}";
+                    Logger.Msg($"HotReload: Removing {albumKey}", false);
+
+                    if (!AlbumManager.LoadedAlbums.TryGetValue(albumKey, out var album))
+                    {
+                        Logger.Warning($"HotReload: Album {albumKey} not found");
+                        continue;
+                    }
+
+                    var uid = $"{AlbumManager.Uid}-{album.Index}";
+
+                    HotLoadedMusicInfos.Remove(uid);
+                    HotLoadedMusicNames.Remove(uid);
+                    HotLoadedMusicAuthors.Remove(uid);
+
+                    // Remove from game music database
+                    try
+                    {
+                        var musicInfo = GlobalDataBase.s_DbMusicTag.GetMusicInfoFromAll(uid);
+                        if (musicInfo != null)
+                        {
+                            GlobalDataBase.s_DbMusicTag.RemoveShowMusicUid(musicInfo);
+                        }
+                        
+                        var allMusicInfo = GlobalDataBase.s_DbMusicTag.m_AllMusicInfo;
+                        if (allMusicInfo != null && allMusicInfo.ContainsKey(uid))
+                        {
+                            allMusicInfo.Remove(uid);
+                        }
+                        
+                        // Remove from all tags (like "All Music" or "Favorites")
+                        if (GlobalDataBase.s_DbMusicTag.m_AllAlbumTagData != null)
+                        {
+                            foreach (var tag in GlobalDataBase.s_DbMusicTag.m_AllAlbumTagData)
+                            {
+                                var tagInfo = tag.Value;
+                                if (tagInfo.m_MusicUids != null && tagInfo.m_MusicUids.Contains(uid))
+                                {
+                                    tagInfo.m_MusicUids.Remove(uid);
+                                }
+                                if (tagInfo.m_DisplayMusicUids != null)
+                                {
+                                    foreach (var d in tagInfo.m_DisplayMusicUids)
+                                    {
+                                        if (d.musicUids != null && d.musicUids.Contains(uid))
+                                        {
+                                            d.musicUids.Remove(uid);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Warning($"HotReload: Failed to remove from DB: {ex.Message}");
+                    }
+
+                    // Remove from ConfigManager
+                    try
+                    {
+                        var config = Singleton<ConfigManager>.instance.GetConfigObject<DBConfigMusicSearchTag>();
+                        if (config != null)
+                        {
+                            if (config.m_Dictionary.ContainsKey(uid))
+                            {
+                                var tagInfo = config.m_Dictionary[uid];
+                                config.m_Dictionary.Remove(uid);
+                                config.list.Remove(tagInfo);
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Warning($"HotReload: Failed to remove search tags: {ex.Message}");
+                    }
+
+                    // Clear resource cache
+                    AlbumManager.LoadedAlbums.Remove(albumKey);
+                    CoverManager.CachedAnimatedCovers.Remove(album.Index);
+                    CoverManager.CachedCovers.Remove(album.Index);
+                    AssetPatch.RemoveFromCache($"{albumKey}_demo");
+                    AssetPatch.RemoveFromCache($"{albumKey}_music");
+                    AssetPatch.RemoveFromCache($"{albumKey}_cover");
+
+                    deletedCount++;
+                    Logger.Msg($"HotReload: Removed {albumKey}", false);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warning($"HotReload: Error removing: {ex.Message}");
+                    Logger.Warning(ex.StackTrace);
+                }
+            }
+
+            return deletedCount;
+        }
+
+        /// <summary>
+        ///     Rebuild Custom Albums tag to update the UID list.
+        /// </summary>
+        private static void RebuildCustomAlbumsTag()
+        {
+            try
+            {
+                var existingTag = GlobalDataBase.dbMusicTag.GetAlbumTagInfo(AlbumManager.Uid);
+                if (existingTag != null)
+                {
+                    var uids = AlbumManager.GetAllUid().ToList();
+                    
+                    if (existingTag.customInfo != null)
+                    {
+                        existingTag.customInfo.music_list = uids.ToIl2Cpp();
+                    }
+                    
+                    if (existingTag.m_MusicUids != null)
+                    {
+                        existingTag.m_MusicUids.Clear();
+                        foreach (var uid in uids) existingTag.m_MusicUids.Add(uid);
+                    }
+                    
+                    if (existingTag.m_DisplayMusicUids != null)
+                    {
+                        foreach (var d in existingTag.m_DisplayMusicUids)
+                        {
+                            if (d.musicUids != null)
+                            {
+                                d.musicUids.Clear();
+                                foreach (var uid in uids) d.musicUids.Add(uid);
+                            }
+                        }
+                    }
+                    
+                    Logger.Msg($"HotReload: Tag updated ({uids.Count} albums)", false);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning($"HotReload: Tag rebuild failed: {ex.Message}");
+            }
+        }
+
+        private static void RefreshUI()
+        {
+            try
+            {
+                var stage = UnityEngine.Object.FindObjectOfType<Il2CppAssets.Scripts.UI.Panels.PnlStage>();
+                if (stage != null && stage.gameObject.activeInHierarchy)
+                {
+                    stage.RefreshStageUI();
+                    Logger.Msg("HotReload: UI refreshed (RefreshStageUI)", false);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning($"HotReload: Failed to refresh UI: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        ///     Consume the queue in Unity's FixedUpdate (main thread safe).
         /// </summary>
         internal static void FixedUpdate()
         {
-            var previousSize = AlbumManager.LoadedAlbums.Count;
-            while (AlbumsAdded.Count > 0) AlbumManager.LoadOne(AlbumsAdded.Dequeue());
-            while (AlbumsDeleted.Count > 0) RemoveAllCachedAssets(AlbumsDeleted.Dequeue());
+            if (AlbumsToAdd.IsEmpty && AlbumsToDelete.IsEmpty) return;
+
+            if (PnlStageInstance == null) return;
+
+            Logger.Msg($"HotReload: Processing queue (add={AlbumsToAdd.Count}, del={AlbumsToDelete.Count})", false);
+            
+            var oldSelectedUid = DataHelper.selectedMusicUidFromInfoList;
+            var oldSelectedAlbumName = AlbumManager.GetAlbumNameFromUid(oldSelectedUid);
+
+            var deletedCount = ProcessDeletions();
+            var addedCount = ProcessAdditions();
+
+            if (deletedCount > 0 || addedCount > 0)
+            {
+                if (addedCount > 0)
+                {
+                    Il2CppAssets.Scripts.UI.Controls.ShowText.ShowInfo(GetLocalizedMessage(AddedTranslations, addedCount));
+                }
+                if (deletedCount > 0)
+                {
+                    Il2CppAssets.Scripts.UI.Controls.ShowText.ShowInfo(GetLocalizedMessage(DeletedTranslations, deletedCount));
+                }
+
+                if (!string.IsNullOrEmpty(oldSelectedAlbumName) && oldSelectedUid != "0-0")
+                {
+                    if (AlbumManager.LoadedAlbums.TryGetValue(oldSelectedAlbumName, out var newAlbum))
+                    {
+                        var newUid = $"{AlbumManager.Uid}-{newAlbum.Index}";
+                        if (newUid != oldSelectedUid)
+                        {
+                            DataHelper.selectedMusicUidFromInfoList = newUid;
+                            Logger.Msg($"HotReload: Updated selected UID from {oldSelectedUid} to {newUid}", false);
+                        }
+                    }
+                    else
+                    {
+                        DataHelper.selectedMusicUidFromInfoList = "0-0";
+                        Logger.Msg($"HotReload: Selected album was deleted. Resetting selection to 0-0", false);
+                    }
+                }
+
+                // Registers the hidden difficulty of the hot-reloaded chart
+                if (addedCount > 0)
+                {
+                    try
+                    {
+                        HiddenSupportPatch.RegisterHiddenChartsDirectly();
+                        Logger.Msg("HotReload: Hidden charts registered directly", false);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Warning($"HotReload: Failed to register hidden charts: {ex.Message}");
+                    }
+                }
+
+                RebuildCustomAlbumsTag();
+                RefreshUI();
+            }
         }
 
         /// <summary>
-        ///     Initializes the AlbumWatcher for adding/deleting/renaming new custom charts.
+        ///     Initialize FileSystemWatcher to monitor Custom_Albums directory changes.
         /// </summary>
         internal static void OnLateInitializeMelon()
         {
-            AlbumManager.AlbumWatcher.Path = AlbumManager.SearchPath;
-            AlbumManager.AlbumWatcher.Filter = AlbumManager.SearchPattern;
+            try
+            {
 
-            AlbumManager.AlbumWatcher.Created += (_, e) =>
-            {
-                Logger.Msg("Added file " + e.Name);
-                while (!IsFileUnlocked(e.FullPath))
-                    // Thread sleep added to not poll the drive a ton
-                    Thread.Sleep(200);
-                AlbumsAdded.Enqueue(e.FullPath);
-            };
-            AlbumManager.AlbumWatcher.Deleted += (s, e) =>
-            {
-                Logger.Msg("Deleted file " + e.Name);
-                AlbumsDeleted.Enqueue(Path.GetFileNameWithoutExtension(e.Name));
-            };
-            AlbumManager.AlbumWatcher.Renamed += (s, e) =>
-            {
-                Logger.Msg("Renamed file " + e.OldName + " -> " + e.Name);
-                RenameAllCachedAssets($"album_{Path.GetFileNameWithoutExtension(e.OldName)}",
-                    $"album_{Path.GetFileNameWithoutExtension(e.Name)}");
-            };
+                var watchPath = Path.GetFullPath(AlbumManager.SearchPath);
+                Logger.Msg($"HotReload: Watching directory: {watchPath}", false);
 
-            // Start the AlbumWatcher
-            AlbumManager.AlbumWatcher.EnableRaisingEvents = true;
+                if (!Directory.Exists(watchPath))
+                {
+                    Logger.Warning($"HotReload: Directory does not exist: {watchPath}");
+                    return;
+                }
+
+                AlbumManager.AlbumWatcher.Path = watchPath;
+                AlbumManager.AlbumWatcher.Filter = AlbumManager.SearchPattern;
+
+                AlbumManager.AlbumWatcher.Created += (_, e) =>
+                {
+                    var now = DateTime.Now;
+                    if (LastFileEvent.TryGetValue(e.FullPath, out var lastTime) && (now - lastTime).TotalMilliseconds < 500) return;
+                    LastFileEvent[e.FullPath] = now;
+
+                    Logger.Msg($"HotReload: Detected new file: {e.Name}", false);
+                    Task.Run(() =>
+                    {
+                        var attempts = 0;
+                        while (!IsFileUnlocked(e.FullPath) && attempts < 50)
+                        {
+                            Thread.Sleep(200);
+                            attempts++;
+                        }
+
+                        if (attempts < 50)
+                        {
+                            AlbumsToAdd.Enqueue(e.FullPath);
+                            Logger.Msg($"HotReload: Queued for addition: {e.Name}", false);
+                        }
+                        else
+                        {
+                            Logger.Warning($"HotReload: Timed out waiting for file: {e.Name}");
+                        }
+                    });
+                };
+
+                AlbumManager.AlbumWatcher.Deleted += (_, e) =>
+                {
+                    var now = DateTime.Now;
+                    if (LastFileEvent.TryGetValue(e.FullPath, out var lastTime) && (now - lastTime).TotalMilliseconds < 500) return;
+                    LastFileEvent[e.FullPath] = now;
+
+                    Logger.Msg($"HotReload: Detected deletion: {e.Name}", false);
+                    AlbumsToDelete.Enqueue(Path.GetFileNameWithoutExtension(e.Name));
+                };
+
+                AlbumManager.AlbumWatcher.Changed += (_, e) =>
+                {
+                    if (e.ChangeType != WatcherChangeTypes.Changed) return;
+                    var now = DateTime.Now;
+                    if (LastFileEvent.TryGetValue(e.FullPath, out var lastTime) && (now - lastTime).TotalMilliseconds < 500) return;
+                    LastFileEvent[e.FullPath] = now;
+
+                    Logger.Msg($"HotReload: Detected change: {e.Name}", false);
+                    Task.Run(() =>
+                    {
+                        var attempts = 0;
+                        while (!IsFileUnlocked(e.FullPath) && attempts < 50)
+                        {
+                            Thread.Sleep(200);
+                            attempts++;
+                        }
+
+                        if (attempts < 50)
+                        {
+                            AlbumsToDelete.Enqueue(Path.GetFileNameWithoutExtension(e.Name));
+                            AlbumsToAdd.Enqueue(e.FullPath);
+                            Logger.Msg($"HotReload: Queued for reload: {e.Name}", false);
+                        }
+                        else
+                        {
+                            Logger.Warning($"HotReload: Timed out waiting for file: {e.Name}");
+                        }
+                    });
+                };
+
+                AlbumManager.AlbumWatcher.Renamed += (_, e) =>
+                {
+                    var now = DateTime.Now;
+                    if (LastFileEvent.TryGetValue(e.FullPath, out var lastTime) && (now - lastTime).TotalMilliseconds < 500) return;
+                    LastFileEvent[e.FullPath] = now;
+
+                    Logger.Msg($"HotReload: Detected rename: {e.OldName} -> {e.Name}", false);
+                    var oldKey = $"album_{Path.GetFileNameWithoutExtension(e.OldName)}";
+                    var newKey = $"album_{Path.GetFileNameWithoutExtension(e.Name)}";
+
+                    if (AlbumManager.LoadedAlbums.Remove(oldKey, out var album))
+                    {
+                        AlbumManager.LoadedAlbums.TryAdd(newKey, album);
+                        AssetPatch.ModifyCacheKey($"{oldKey}_demo", $"{newKey}_demo");
+                        AssetPatch.ModifyCacheKey($"{oldKey}_music", $"{newKey}_music");
+                        AssetPatch.ModifyCacheKey($"{oldKey}_cover", $"{newKey}_cover");
+                        Logger.Msg($"HotReload: Renamed {oldKey} -> {newKey}", false);
+                    }
+                    else
+                    {
+                        // Old album was not loaded (e.g. didn't match 'test*.mdm'). Treat this rename as a new creation event.
+                        Logger.Msg($"HotReload: Old file was not loaded, treating as new file: {e.Name}", false);
+                        Task.Run(() =>
+                        {
+                            var attempts = 0;
+                            while (!IsFileUnlocked(e.FullPath) && attempts < 50)
+                            {
+                                Thread.Sleep(200);
+                                attempts++;
+                            }
+
+                            if (attempts < 50)
+                            {
+                                AlbumsToAdd.Enqueue(e.FullPath);
+                                Logger.Msg($"HotReload: Queued for addition: {e.Name}", false);
+                            }
+                            else
+                            {
+                                Logger.Warning($"HotReload: Timed out waiting for file: {e.Name}");
+                            }
+                        });
+                    }
+                };
+
+                AlbumManager.AlbumWatcher.EnableRaisingEvents = true;
+                Logger.Msg("HotReload: FileSystemWatcher initialized!", false);
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning($"HotReload: Init failed: {ex.Message}");
+                Logger.Warning(ex.StackTrace);
+            }
         }
 
+        // ============================================================
+        // Harmony Patches
+        // ============================================================
+
+        /// <summary>
+        ///     Intercepts GetMusicInfoFromAll: Returns our manually created MusicInfo
+        ///     when the game looks up a hot-loaded song.
+        /// </summary>
+        [HarmonyPatch(typeof(DBMusicTag), nameof(DBMusicTag.GetMusicInfoFromAll))]
+        internal static class GetMusicInfoFromAllPatch
+        {
+            private static void Postfix(string musicUid, ref MusicInfo __result)
+            {
+                if (string.IsNullOrEmpty(musicUid)) return;
+                
+                if (HotLoadedMusicInfos.TryGetValue(musicUid, out var hotMusicInfo))
+                {
+                    __result = hotMusicInfo;
+                }
+            }
+        }
+
+
+
+
+
+
+
+        /// <summary>
+        ///     Capture PnlStage instance reference.
+        /// </summary>
         [HarmonyPatch(typeof(PnlStage), nameof(PnlStage.PreWarm))]
         internal static class StagePreWarmPatch
         {
             private static void Postfix(PnlStage __instance)
             {
-                Logger.Msg($"PnlStage instance retrieved. Null = {__instance == null}");
                 PnlStageInstance = __instance;
             }
         }

--- a/Patches/HiddenSupportPatch.cs
+++ b/Patches/HiddenSupportPatch.cs
@@ -22,6 +22,74 @@ namespace CustomAlbums.Patches
             MusicTagPatch.HasUpdate = true;
         }
 
+        internal static void RegisterHiddenChartsDirectly()
+        {
+            var specialSongMgr = Singleton<SpecialSongManager>.instance;
+            if (specialSongMgr == null) return;
+
+            Il2CppSystem.Collections.Generic.List<string> newHiddenUids = new();
+
+            foreach (var (key, album) in AlbumManager.LoadedAlbums)
+            {
+                if (!album.HasDifficulty(4) && !album.HasDifficulty(5)) continue;
+
+                var albumUid = album.Uid;
+
+                if (album.HasDifficulty(5) && !DBMusicTagDefine.s_BarrageModeSongUid.Contains(albumUid))
+                {
+                    var oldArr = DBMusicTagDefine.s_BarrageModeSongUid;
+                    var newArr = new Il2CppStringArray(oldArr.Length + 1);
+                    for (var i = 0; i < oldArr.Length; i++) newArr[i] = oldArr[i];
+                    newArr[^1] = albumUid;
+                    DBMusicTagDefine.s_BarrageModeSongUid = newArr;
+                }
+
+                if (!album.HasDifficulty(4)) continue;
+                if (!LoadedHiddens.Add(albumUid)) continue;
+                newHiddenUids.Add(albumUid);
+
+                if (!specialSongMgr.m_HideBmsInfos.ContainsKey(albumUid))
+                {
+                    var triggerDiff = album.Info.HideBmsDifficulty == "0"
+                        ? album.HasDifficulty(3) ? 3 : 2
+                        : album.Info.HideBmsDifficulty.ParseAsInt();
+
+                    specialSongMgr.m_HideBmsInfos.Add(albumUid,
+                        new SpecialSongManager.HideBmsInfo(
+                            albumUid,
+                            triggerDiff,
+                            4,
+                            $"{key}_map4",
+                            new Func<bool>(() => specialSongMgr.IsInvokeHideBms(albumUid))
+                        ));
+
+                    var hideMusicInfo = new HideMusicInfo
+                    {
+                        musicUid = albumUid,
+                        invokeType = album.Info.HideBmsMode switch
+                        {
+                            "CLICK" => (int)HiddenInvokeType.Click,
+                            "PRESS" => (int)HiddenInvokeType.LongPress,
+                            "TOGGLE" => (int)HiddenInvokeType.Toggle,
+                            _ => (int)HiddenInvokeType.None
+                        }
+                    };
+                    specialSongMgr.m_ConfigHideMusic.m_HideMusicObjectMapping[albumUid] = hideMusicInfo;
+                }
+            }
+
+            if (newHiddenUids.Count <= 0) return;
+
+            var oldHidden = DBMusicTagDefine.s_HiddenLocal;
+            var newHidden = new Il2CppStringArray(oldHidden.Length + newHiddenUids.Count);
+            for (var i = 0; i < oldHidden.Length; i++) newHidden[i] = oldHidden[i];
+            for (var i = 0; i < newHiddenUids.Count; i++) newHidden[i + oldHidden.Length] = newHiddenUids[i];
+            DBMusicTagDefine.s_HiddenLocal = newHidden;
+
+            var tagInfo = GlobalDataBase.dbMusicTag.GetAlbumTagInfo(32776);
+            tagInfo?.AddTagUids(newHiddenUids);
+        }
+
         [HarmonyPatch(typeof(SpecialSongManager), nameof(SpecialSongManager.InitHideBmsInfoDic))]
         internal static class HideBmsInfoDicPatch
         {

--- a/Patches/SavePatch.cs
+++ b/Patches/SavePatch.cs
@@ -200,12 +200,6 @@ namespace CustomAlbums.Patches
                     OriginalNoNetText = noNetComp.text;
                     FirstRun = false;
                 }
-                // Check first run case when on a custom and HQ is not present
-                if (uid.StartsWith($"{AlbumManager.Uid}-") && _hqPresent == null && !HQPresent)
-                {
-                    Logger.Warning("Headquarters is not installed! Custom chart leaderboards will not function.");
-                }
-
                 // Vanilla chart or HQ present
                 if (!uid.StartsWith($"{AlbumManager.Uid}-") || HQPresent)
                 {
@@ -218,6 +212,73 @@ namespace CustomAlbums.Patches
                 __instance.noNet.SetActive(true);
                 return false;
             }
+
+            private static System.Exception Finalizer(System.Exception __exception, PnlRank __instance)
+            {
+                if (__exception != null)
+                {
+                    Logger.Error($"[PnlRank.UIRefresh] EXCEPTION THROWN: {__exception.Message}\n{__exception.StackTrace}");
+                    if (__instance != null && __instance.noNet != null)
+                    {
+                        var noNetComp = __instance.noNet.GetComponent<UnityEngine.UI.Text>();
+                        if (noNetComp != null)
+                        {
+                            noNetComp.text = $"CRASH: {__exception.Message}\nCheck MelonLoader console for details.";
+                        }
+                        __instance.noNet.SetActive(true);
+                        if (__instance.server != null) __instance.server.SetActive(false);
+                    }
+                }
+                return null;
+            }
+        }
+
+
+        ///     Corrects the difficulty parameter for hot-reloaded custom charts. The game passes the star difficulty (e.g., 9)
+        ///     instead of the difficulty index (1=Easy, 2=Hard, 3=Master) for hot-reloaded charts, causing HQ's
+        ///     Sheets[difficulty] to throw KeyNotFoundException → AccessViolationException and crash the game.
+        ///     Correct difficulty to selectedDiffTglIndex via ref to allow normal processing by HQ.
+
+        [HarmonyPatch(typeof(GameAccountSystem), nameof(GameAccountSystem.GetRanks))]
+        internal static class SafeGetRanksPatch
+        {
+            [HarmonyPriority(Priority.First)]
+            private static bool Prefix(string musicUid, ref int difficulty)
+            {
+                if (!musicUid.StartsWith($"{AlbumManager.Uid}-")) return true;
+
+                try
+                {
+                    var album = AlbumManager.GetByUid(musicUid);
+                    if (album == null)
+                    {
+                        Logger.Warning($"GetRanks: album does not exist (uid={musicUid}), skipping");
+                        return false;
+                    }
+
+                    // difficulty is in Sheets -> valid, pass directly
+                    if (album.Sheets.ContainsKey(difficulty)) return true;
+
+                    // difficulty is not in Sheets -> replace with the currently selected difficulty toggle index
+                    var corrected = GlobalDataBase.s_DbMusicTag.selectedDiffTglIndex;
+                    Logger.Warning($"GetRanks: difficulty {difficulty} → {corrected} (uid={musicUid})");
+                    difficulty = corrected;
+
+                    // Double check the corrected value
+                    if (!album.Sheets.ContainsKey(difficulty))
+                    {
+                        Logger.Warning($"GetRanks: still invalid after correction diff={difficulty}, skipping");
+                        return false;
+                    }
+                }
+                catch (System.Exception ex)
+                {
+                    Logger.Error($"GetRanks validation exception: {ex.Message}");
+                    return false;
+                }
+
+                return true;
+            }
         }
 
         //
@@ -227,7 +288,6 @@ namespace CustomAlbums.Patches
         // TODO: Find a way to inject hidden and favorite charts without using vanilla save -- below are workarounds for quick release.
         private static void CleanCustomData()
         {
-
             DataHelper.hides.RemoveAll((Il2CppSystem.Predicate<string>)(uid => uid.StartsWith($"{AlbumManager.Uid}-")));
             DataHelper.history.RemoveAll(
                 (Il2CppSystem.Predicate<string>)(uid => uid.StartsWith($"{AlbumManager.Uid}-")));
@@ -552,7 +612,7 @@ namespace CustomAlbums.Patches
         [HarmonyPatch(typeof(GameAccountSystem), nameof(GameAccountSystem.RefreshDatas))]
         internal class RefreshDatasPatch
         {
-            private static void Prefix()
+            private static void Postfix()
             {
                 Backup.InitBackups();
                 SaveSaveFile();


### PR DESCRIPTION
## Summary

Adds hot reload support for custom albums.

This allows `.mdm` files in the custom albums directory to be added, removed, changed, or renamed while the game is running. The runtime album database, music info cache, custom album tag list, hidden chart data, covers, and stage UI are refreshed after file changes.

## Changes

- Add `FileSystemWatcher` handling for custom album add/delete/change/rename events
- Queue file watcher events and process them on the main thread
- Rebuild runtime album metadata after hot reload changes
- Refresh custom album tag data and stage UI after changes
- Support hot-reloaded hidden charts
- Fix demo audio cleanup so reloaded preview audio does not get cut off incorrectly

## Validation

- Built successfully with `dotnet build CustomAlbums.csproj --no-restore`